### PR TITLE
SYS-88: Modify codenotify message

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,8 +9,8 @@ from fnmatch import fnmatch
 import requests
 
 
-BASE_PR_COMMENT = "❓Changes in watched files detected, Do these need to be kept in sync between front-end and calculation-module?\ncc:{}"
-PR_COMMENT_TITLE = "<!-- codenotify report -->\n"
+BASE_PR_COMMENT = "❓ Do any of your changes impact compatibility between `performancecentre` and `calculation-engine`? If you're not sure, refer to [this confluence page](https://performancecentre.atlassian.net/wiki/spaces/Tech/pages/2704605191/), or reach out in `#team-systems`."
+PR_COMMENT_TITLE = "Reminder: Calc Engine Compatibility"
 CODEPROS_FILE = "CODEPROS"
 
 # Env vars
@@ -219,7 +219,10 @@ def comment_on_pr(pr_id, pros, changed_files):
             comment_id = comment["id"]
             break
 
-    comment = BASE_PR_COMMENT.format(" ".join(pros))
+    comment = BASE_PR_COMMENT
+    if pros:
+        comment.format("\nCC: ".join(pros))
+        
     comment = f"{PR_COMMENT_TITLE}\n{comment}"
     if changed_files:
         comment += "\nList of files:\n* "
@@ -283,10 +286,8 @@ def main():
                 print(f"Rule {code_pro_glob.glob} matches {changed_file}")
                 pros |= code_pro_glob.pros
                 changed_files.update(changed_file.split())
-    if pros:
+
         comment_on_pr(pr_id, pros, changed_files)
-    else:
-        print("No pros found for these files")
 
 
 if __name__ == "__main__":

--- a/test_main.py
+++ b/test_main.py
@@ -15,10 +15,11 @@ from main import (
     GRAPHQL_UPDATE_PR_COMMENT,
     PR_COMMENT_TITLE,
     CodeProsGlob,
+    CodeProsDict,
     GitHubGraphQLClient,
     comment_on_pr,
     get_changed_files,
-    get_code_pros_globs,
+    get_code_pros_dict,
     get_github_event_data,
     globulize_filepath,
     main,
@@ -77,13 +78,16 @@ class TestCodeProsGlobs(unittest.TestCase):
             m.return_value.__iter__ = lambda self: self
             m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
 
-            code_pro_globs = get_code_pros_globs(CODEPROS_FILE, set())
+            code_pro_dict = get_code_pros_dict(CODEPROS_FILE, set())
+            code_pro_globs = code_pro_dict["globs"]
+            code_pros_message = code_pro_dict["message"]
 
+        self.assertEqual(code_pros_message, "")
         self.assertEqual(code_pro_globs, [])
 
     @patch("os.path.exists", return_value=False)
     def test_codepros_file_missing(self, path_exists):
-        code_pro_globs = get_code_pros_globs(CODEPROS_FILE, set())
+        code_pro_globs = get_code_pros_dict(CODEPROS_FILE, set())
         self.assertEqual(code_pro_globs, [])
 
     def test_codepros_file_missing_file(self):
@@ -92,7 +96,7 @@ class TestCodeProsGlobs(unittest.TestCase):
             m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
 
             with self.assertRaises(IOError) as ex:
-                _ = get_code_pros_globs(CODEPROS_FILE, set())
+                _ = get_code_pros_dict(CODEPROS_FILE, set())
 
             self.assertTrue("line missing file" in str(ex.exception))
 
@@ -102,7 +106,7 @@ class TestCodeProsGlobs(unittest.TestCase):
             m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
 
             with self.assertRaises(IOError) as ex:
-                _ = get_code_pros_globs(CODEPROS_FILE, set())
+                _ = get_code_pros_dict(CODEPROS_FILE, set())
 
             self.assertTrue("pro incorrect" in str(ex.exception))
 
@@ -111,19 +115,24 @@ class TestCodeProsGlobs(unittest.TestCase):
             m.return_value.__iter__ = lambda self: self
             m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
 
-            code_pros_globs = get_code_pros_globs(CODEPROS_FILE, {"@pro2"})
+            code_pros_globs = get_code_pros_dict(CODEPROS_FILE, {"@pro2"})["globs"]
 
         self.assertEqual(len(code_pros_globs), 1)
         self.assertEqual(code_pros_globs[0].pros, {"@pro"})
         self.assertEqual(code_pros_globs[0].glob, "main.py")
 
     def test_good_codepros_file(self):
-        with patch("builtins.open", new_callable=mock_open, read_data="main.py @pro\ntest_main.py @pro\n") as m:
+        with patch("builtins.open", new_callable=mock_open, read_data="TITLE=Test title\nMESSAGE=Test message\nmain.py @pro\ntest_main.py @pro\n") as m:
             m.return_value.__iter__ = lambda self: self
             m.return_value.__next__ = lambda self: next(iter(self.readline, ''))
 
-            code_pros_globs = get_code_pros_globs(CODEPROS_FILE, set())
+            code_pros_dict = get_code_pros_dict(CODEPROS_FILE, set())
+            code_pros_title = code_pros_dict["title"]
+            code_pros_message = code_pros_dict["message"]
+            code_pros_globs = code_pros_dict["globs"]
 
+        self.assertEqual(code_pros_title, "Test title")
+        self.assertEqual(code_pros_message, "Test message")
         self.assertEqual(len(code_pros_globs), 2)
         self.assertEqual(code_pros_globs[0].pros, {"@pro"})
         self.assertEqual(code_pros_globs[0].glob, "main.py")
@@ -189,12 +198,12 @@ class TestCommentOnPR(unittest.TestCase):
         "main.github_graphql_client.make_request",
         return_value={"data": {"node": {"comments": {"nodes": [{"id": 1, "body": PR_COMMENT_TITLE}]}}}})
     def test_update_comment(self, github_graphql):
-        comment_on_pr(123, {"@pro"}, {"main.py", "test_main.py"})
+        comment_on_pr(123, "Test title", "Test PR message", {"@pro"}, {"main.py", "test_main.py"})
         self.assertEqual(github_graphql.call_args[0][0], GRAPHQL_UPDATE_PR_COMMENT)
 
     @patch("main.github_graphql_client.make_request", return_value={"data": {"node": {"comments": {"nodes": []}}}})
     def test_add_new_comment(self, github_graphql):
-        comment_on_pr(123, {"@pro"}, {"main.py", "test_main.py"})
+        comment_on_pr(123, "Test title", "Test PR message", {"@pro"}, {"main.py", "test_main.py"})
         self.assertEqual(github_graphql.call_args[0][0], GRAPHQL_ADD_PR_COMMENT)
 
 
@@ -243,32 +252,40 @@ class TestMain(unittest.TestCase):
         os.environ[GITHUB_WORKSPACE_ENV_VAR] = "full_flow"
         os.environ[GITHUB_EVENT_PATH_ENV_VAR] = "full_flow"
 
-    @patch("main.get_code_pros_globs")
-    def test_ignore_draft_pr(self, get_code_pros_globs):
+    @patch("main.get_code_pros_dict")
+    def test_ignore_draft_pr(self, get_code_pros_dict):
         event_data = deepcopy(self.GITHUB_EVENT_DATA)
         event_data["pull_request"]["draft"] = True
 
         with patch("main.get_github_event_data", return_value=event_data):
             main()
 
-        get_code_pros_globs.assert_not_called()
+        get_code_pros_dict.assert_not_called()
 
     @patch("main.get_changed_files")
     @patch("main.get_github_event_data", return_value=GITHUB_EVENT_DATA)
     def test_no_code_pro_globs(self, get_github_event_data_mock, get_changed_files_mock):
-        with patch("main.get_code_pros_globs", return_value=[]):
+        with patch("main.get_code_pros_dict", return_value={
+            "title": "",
+            "message": "",
+            "globs": [],
+        }):
             main()
 
         get_changed_files_mock.assert_not_called()
 
     @patch("main.get_changed_files", return_value=["main.py"])
-    @patch("main.get_code_pros_globs", return_value=[CodeProsGlob("*", {"@pro"})])
+    @patch("main.get_code_pros_dict", return_value={
+        "title": "Test title",
+        "message": "Test message",
+        "globs": [ CodeProsGlob("*", {"@pro"}) ],
+    })
     @patch("main.get_github_event_data", return_value=GITHUB_EVENT_DATA)
-    def test_full_flow(self, get_github_event_data_mock, get_code_pros_globs_mock, get_changed_files_mock):
+    def test_full_flow(self, get_github_event_data_mock, get_code_pros_dict_mock, get_changed_files_mock):
         with patch("main.comment_on_pr") as comment_on_pr_mock:
             main()
 
-        comment_on_pr_mock.assert_called_with(self.GITHUB_EVENT_DATA["pull_request"]["node_id"], {"@pro"}, {"main.py"})
+        comment_on_pr_mock.assert_called_with(self.GITHUB_EVENT_DATA["pull_request"]["node_id"], "Test title", "Test message", {"@pro"}, {"main.py"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update codenotify to retrieve PR comment title and message from `CODEPROS` file instead of hardcoding it. This is to ensure that any info we add to the PR comment that could reveal details of system architecture aren't in a public repository.